### PR TITLE
Don't override newer security protocols

### DIFF
--- a/DeployClient/API.cs
+++ b/DeployClient/API.cs
@@ -16,7 +16,7 @@ namespace DeployClient
 
         private static HttpClient BuildClient()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             HttpClient client = new HttpClient()
             {


### PR DESCRIPTION
Set TLS 1.2 as the chosen security protocol only if the globally configured protocol isn't newer.