### PR TITLE
Handle HTTP error

### DIFF
--- a/DeployClient/API.cs
+++ b/DeployClient/API.cs
@@ -59,7 +59,16 @@ namespace DeployClient
 
             using (HttpClient client = BuildClient())
             {
-                var httpResponse = await client.GetAsync(endpoint);
+                HttpResponseMessage httpResponse;
+                try
+                {
+                    httpResponse = await client.GetAsync(endpoint);
+                }
+                catch
+                {
+                    return (false, new Dictionary<string, dynamic>(0));
+                }
+                
                 if (httpResponse.StatusCode == HttpStatusCode.OK)
                 {
                     string json = await httpResponse.Content.ReadAsStringAsync();

--- a/DeployClient/API.cs
+++ b/DeployClient/API.cs
@@ -62,7 +62,7 @@ namespace DeployClient
                 var httpResponse = await client.GetAsync(endpoint);
                 if (httpResponse.StatusCode == HttpStatusCode.OK)
                 {
-                    string json = httpResponse.Content.ReadAsStringAsync().Result;
+                    string json = await httpResponse.Content.ReadAsStringAsync();
                     return (true, jsonSer.Deserialize<Dictionary<string, dynamic>>(json));
                 }
 


### PR DESCRIPTION
We're seeing a semi-consistent error during install, where retrying works.  This is an adjustment to the error handling to allow this error to trigger the retry logic instead of failing immediately.

<details>
<summary>Error details</summary>
<pre>
> Starting installation...
> Exception caught at: 9/11/2020 6:45:55 PM.
> System.Net.Http.HttpRequestException | An error occurred while sending the request.
>    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
>    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
>    at DeployClient.API.<GetSessionAsync>d__3.MoveNext() in C:\DNNDev\CantarusCore\PolyDeploy\DeployClient\API.cs:line 62
> --- End of stack trace from previous location where exception was thrown ---
>    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
>    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
>    at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
>    at DeployClient.Program.<Main>d__2.MoveNext() in C:\DNNDev\CantarusCore\PolyDeploy\DeployClient\Program.cs:line 148
> System.Net.WebException | Unable to connect to the remote server
>    at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult)
>    at System.Net.Http.HttpClientHandler.GetResponseCallback(IAsyncResult ar)
> System.Net.Sockets.SocketException | A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond 12.147.61.210:443
>    at System.Net.Sockets.Socket.InternalEndConnect(IAsyncResult asyncResult)
>    at System.Net.Sockets.Socket.EndConnect(IAsyncResult asyncResult)
>    at System.Net.ServicePoint.ConnectSocketInternal(Boolean connectFailure, Socket s4, Socket s6, Socket& socket, IPAddress& address, ConnectSocketState state, IAsyncResult asyncResult, Exception& exception)
</pre>
</details>